### PR TITLE
fix: Use same default port as the CLI tool

### DIFF
--- a/src/main/java/org/jbake/maven/InlineMojo.java
+++ b/src/main/java/org/jbake/maven/InlineMojo.java
@@ -1,5 +1,7 @@
 package org.jbake.maven;
 
+import org.apache.commons.configuration.ConfigurationException;
+
 /*
  * Copyright 2013 ingenieux Labs
  *
@@ -48,8 +50,21 @@ public class InlineMojo extends WatchMojo {
   /**
    * Listen Port
    */
-  @Parameter(property = "jbake.port", defaultValue = "8820")
+  @Parameter(property = "jbake.port")
   private Integer port;
+
+  private int getPort() {
+    if (this.port == null) {
+      try {
+        return createConfiguration().getServerPort();
+      } catch (ConfigurationException e) {
+        // ignore since default will be returned
+      }
+    } else {
+      return this.port;
+    }
+    return 8820;
+  }
 
   protected void stopServer() throws MojoExecutionException {
     stop();
@@ -59,7 +74,7 @@ public class InlineMojo extends WatchMojo {
     externalStaticFileLocation(outputDirectory.getPath());
 
     ipAddress(listenAddress);
-    port(this.port);
+    port(getPort());
 
     init();
 

--- a/src/main/java/org/jbake/maven/InlineMojo.java
+++ b/src/main/java/org/jbake/maven/InlineMojo.java
@@ -48,7 +48,7 @@ public class InlineMojo extends WatchMojo {
   /**
    * Listen Port
    */
-  @Parameter(property = "jbake.port", defaultValue = "8080")
+  @Parameter(property = "jbake.port", defaultValue = "8820")
   private Integer port;
 
   protected void stopServer() throws MojoExecutionException {


### PR DESCRIPTION
Addresses #27 by changing the hard coded default in this project. It seems to me that this can't mirror some setting in jbake-org/jbake since there is no public final static property containing the default port for the CLI (it is instead in default.properties).