### PR TITLE
Updated jbake-core dependency to 2.6.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 
 jdk:
-  - oraclejdk7
-  - openjdk6
+  - oraclejdk11
+  - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>org.jbake</groupId>
                 <artifactId>jbake-core</artifactId>
-                <version>2.6.6</version>
+                <version>2.6.7</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Could this be considered, please?

Would it be possible to release new maven plugin with that change, as I'd like to have jbake-org/jbake#682 without overriding plugin's dependency myself.